### PR TITLE
Update 02-prereqs.markdown

### DIFF
--- a/02-prereqs.markdown
+++ b/02-prereqs.markdown
@@ -166,7 +166,7 @@ source $MESASDK_ROOT/bin/mesasdk_init.csh
 {% endhighlight %}
 
 One caveat is that if you put the MESA SDK in your shell profile,
-you'll always be using gcc 4.9 which may be a compatibility issue if
+you'll always be using the MESA SDK supplied version of gcc which may be a compatibility issue if
 you work with other other codes.  Alternative (unsupported)
 initialization scripts are available [here][mesasdk-init].
 


### PR DESCRIPTION
> No, that's just the documentation being out of date. gcc 4.10 is the current sdk version
> Rob

reworded so that we don't have to update the prose everytime a new gcc is rolled out.

fxt
