### PR TITLE
stop sidebar items from jumping around when switching sites

### DIFF
--- a/css/andreas07.css
+++ b/css/andreas07.css
@@ -41,7 +41,7 @@ a img:hover {background:#0000CE; border-color:#0000CE;}
 /* Navigation menu */
 #menu ul {list-style-type: none; margin: 0px; padding: 0px; font-size: 1.0em;}
 #menu li {margin: 0px; padding: 0px}
-#menu a, #menu span {display:block; width:202px; padding:5px 18px 5px 0; color:#606060; background:#e0e0e0; font-size:1.4em; font-weight:normal; text-decoration:none; letter-spacing:-1px;}
+#menu a, #menu span {display:block; width:202px; padding:5px 18px 5px 0; color:#606060; background:#e0e0e0; font-size:1.4em; font-weight:normal; text-decoration:none; letter-spacing:-1px; border-top: 2px #e0e0e0 solid; border-bottom: 2px #e0e0e0 solid;}
 #menu a:hover, #menu span:hover {color:#303030; background:#f0f0f0;}
 #menu a.active, #menu li.webgen-menu-item-selected a, #menu li.webgen-menu-item-selected span, #menu li.webgen-menu-submenu-inhierarchy a, #menu li.webgen-menu-submenu-inhierarchy span {padding:5px 18px 5px 0; background:#fafafa; border-top:2px solid #c0c0c0; border-bottom:2px solid #c0c0c0;}
 #menu a.active:hover, #menu li.webgen-menu-item-selected a:hover, #menu li.webgen-menu-item-selected span:hover, #menu li.webgen-menu-submenu-inhierarchy a:hover, #menu li.webgen-menu-submenu-inhierarchy span:hover {color:#505050; background:#fafafa;}


### PR DESCRIPTION
It bugged me slightly that the position of the sidebar text was jumping around when switching between pages, so I created this simple fix.